### PR TITLE
Support auto-configuration class for spring boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,8 @@
         <jdk.version>1.6</jdk.version>
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${encoding}</project.reporting.outputEncoding>
-        <spring.version>3.2.6.RELEASE</spring.version>
+        <spring.version>4.3.4.RELEASE</spring.version>
+        <spring-boot.version>1.4.2.RELEASE</spring-boot.version>
     </properties>
 
     <organization>
@@ -119,6 +120,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring-boot.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.0.1</version>
@@ -128,7 +135,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -153,6 +160,12 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/mixer2/spring/boot/Mixer2AutoConfiguration.java
+++ b/src/main/java/org/mixer2/spring/boot/Mixer2AutoConfiguration.java
@@ -1,0 +1,105 @@
+package org.mixer2.spring.boot;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mixer2.Mixer2Engine;
+import org.mixer2.spring.webmvc.Mixer2XhtmlViewResolver;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.ViewResolver;
+
+import java.util.List;
+
+@Configuration
+@ConditionalOnClass(Mixer2Engine.class)
+@AutoConfigureAfter(WebMvcAutoConfiguration.class)
+@EnableConfigurationProperties(Mixer2Properties.class)
+public class Mixer2AutoConfiguration {
+
+    private static Log log = LogFactory.getLog(Mixer2AutoConfiguration.class);
+
+    @Bean
+    @ConditionalOnMissingBean
+    public Mixer2Engine mixer2Engine() {
+        return new Mixer2Engine();
+    }
+
+    @Configuration
+    @ConditionalOnClass(ViewResolver.class)
+    public static class Mixer2ViewConfiguration {
+
+        private final Mixer2Engine mixer2Engine;
+        private final Mixer2Properties properties;
+        private final BeanFactory beanFactory;
+
+        @Autowired
+        public Mixer2ViewConfiguration(Mixer2Engine mixer2Engine, Mixer2Properties properties, BeanFactory beanFactory) {
+            this.mixer2Engine = mixer2Engine;
+            this.properties = properties;
+            this.beanFactory = beanFactory;
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public Mixer2XhtmlViewResolver mixer2XhtmlViewResolver() {
+            Mixer2XhtmlViewResolver resolver = new Mixer2XhtmlViewResolver();
+            resolver.setOrder(properties.getOrder());
+            resolver.setMixer2Engine(this.mixer2Engine);
+            resolver.setPrefix(properties.getPrefix());
+            resolver.setSuffix(properties.getSuffix());
+            if (properties.getViewBasePackage() != null) {
+                resolver.setBasePackage(properties.getViewBasePackage());
+            } else if (AutoConfigurationPackages.has(beanFactory)) {
+                List<String> packages = AutoConfigurationPackages.get(beanFactory);
+                if (packages.size() == 1) {
+                    String viewBasePackage = packages.get(0) + ".web.view";
+                    resolver.setBasePackage(viewBasePackage);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Apply '" + viewBasePackage + "' to the base package of view.");
+                    }
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Skip auto-detecting base package of view because found multiple base packages. found base packages : " + packages);
+                    }
+                }
+            }
+            if (properties.getViewClassNameSuffix() != null) {
+                resolver.setClassNameSuffix(properties.getViewClassNameSuffix());
+            }
+            if (properties.getContentType() != null) {
+                resolver.setContentType(properties.getContentType());
+            }
+            if (properties.getDocType() != null) {
+                resolver.setDocType(properties.getDocType());
+            }
+            if (properties.getReturnNullIfTemplateFileNotFound() != null) {
+                resolver.setReturnNullIfTemplateFileNotFound(properties.getReturnNullIfTemplateFileNotFound());
+            }
+            if (properties.getRaiseErrorIfViewClassNotFound() != null) {
+                resolver.setRaiseErrorIfViewClassNotFound(properties.getRaiseErrorIfViewClassNotFound());
+            }
+            if (properties.getCache() != null) {
+                resolver.setCache(properties.getCache());
+            }
+            if (resolver.isCache()) {
+                if (properties.getCacheLimit() != null) {
+                    resolver.setCacheLimit(properties.getCacheLimit());
+                }
+                if (properties.getCacheUnresolved() != null) {
+                    resolver.setCacheUnresolved(properties.getCacheUnresolved());
+                }
+            }
+            return resolver;
+        }
+
+    }
+
+}

--- a/src/main/java/org/mixer2/spring/boot/Mixer2Properties.java
+++ b/src/main/java/org/mixer2/spring/boot/Mixer2Properties.java
@@ -1,0 +1,132 @@
+package org.mixer2.spring.boot;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.io.Serializable;
+
+@ConfigurationProperties(prefix = "mixer2")
+public class Mixer2Properties implements Serializable {
+
+    private static final long serialVersionUID = -8282705230257476884L;
+
+    private int order = 1;
+
+    private String prefix = "classpath:/m2mockup/templates/";
+
+    private String suffix = ".html";
+
+    private String viewBasePackage;
+
+    private String viewClassNameSuffix;
+
+    private String docType;
+
+    private String contentType;
+
+    private Boolean returnNullIfTemplateFileNotFound;
+
+    private Boolean raiseErrorIfViewClassNotFound;
+
+    private Integer cacheLimit;
+
+    private Boolean cacheUnresolved;
+
+    private Boolean cache;
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public void setSuffix(String suffix) {
+        this.suffix = suffix;
+    }
+
+    public String getViewBasePackage() {
+        return viewBasePackage;
+    }
+
+    public void setViewBasePackage(String viewBasePackage) {
+        this.viewBasePackage = viewBasePackage;
+    }
+
+    public String getViewClassNameSuffix() {
+        return viewClassNameSuffix;
+    }
+
+    public void setViewClassNameSuffix(String viewClassNameSuffix) {
+        this.viewClassNameSuffix = viewClassNameSuffix;
+    }
+
+    public String getDocType() {
+        return docType;
+    }
+
+    public void setDocType(String docType) {
+        this.docType = docType;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public Boolean getReturnNullIfTemplateFileNotFound() {
+        return returnNullIfTemplateFileNotFound;
+    }
+
+    public void setReturnNullIfTemplateFileNotFound(Boolean returnNullIfTemplateFileNotFound) {
+        this.returnNullIfTemplateFileNotFound = returnNullIfTemplateFileNotFound;
+    }
+
+    public Boolean getRaiseErrorIfViewClassNotFound() {
+        return raiseErrorIfViewClassNotFound;
+    }
+
+    public void setRaiseErrorIfViewClassNotFound(Boolean raiseErrorIfViewClassNotFound) {
+        this.raiseErrorIfViewClassNotFound = raiseErrorIfViewClassNotFound;
+    }
+
+    public Integer getCacheLimit() {
+        return cacheLimit;
+    }
+
+    public void setCacheLimit(Integer cacheLimit) {
+        this.cacheLimit = cacheLimit;
+    }
+
+    public Boolean getCacheUnresolved() {
+        return cacheUnresolved;
+    }
+
+    public void setCacheUnresolved(Boolean cacheUnresolved) {
+        this.cacheUnresolved = cacheUnresolved;
+    }
+
+    public Boolean getCache() {
+        return cache;
+    }
+
+    public void setCache(Boolean cache) {
+        this.cache = cache;
+    }
+
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Auto Configure
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.mixer2.spring.boot.Mixer2AutoConfiguration

--- a/src/test/java/org/mixer2/spring/boot/Mixer2AutoConfigurationTest.java
+++ b/src/test/java/org/mixer2/spring/boot/Mixer2AutoConfigurationTest.java
@@ -1,0 +1,237 @@
+package org.mixer2.spring.boot;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mixer2.Mixer2Engine;
+import org.mixer2.jaxb.exception.Mixer2JAXBException;
+import org.mixer2.jaxb.xhtml.Html;
+import org.mixer2.spring.boot.app.view.CustomScreenView;
+import org.mixer2.spring.boot.config.SubPackageAppConfig;
+import org.mixer2.spring.boot.web.view.DefaultView;
+import org.mixer2.spring.webmvc.AbstractMixer2XhtmlView;
+import org.mixer2.spring.webmvc.Mixer2XhtmlViewResolver;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.View;
+
+import java.util.Locale;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class Mixer2AutoConfigurationTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private AnnotationConfigApplicationContext context;
+
+    @Before
+    public void init() {
+        this.context = new AnnotationConfigApplicationContext();
+    }
+
+    @After
+    public void closeContext() {
+        if (this.context != null) {
+            this.context.close();
+        }
+    }
+
+    @Test
+    public void testDefaultConfiguration() throws Exception {
+        this.context.register(AppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        assertThat(this.context.getBeanNamesForType(Mixer2Engine.class).length, is(1));
+
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        assertThat(viewResolver.getOrder(), is(1));
+        assertThat(viewResolver.isCache(), is(true));
+        assertThat(viewResolver.getCacheLimit(), is(1024));
+        assertThat(viewResolver.isCacheUnresolved(), is(true));
+
+        DefaultView view = (DefaultView) viewResolver.resolveViewName("default", Locale.US);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        view.render(null, new MockHttpServletRequest(), response);
+        assertThat(response.getContentAsString(), is("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<body>default</body>\n</html>"));
+        assertThat(response.getContentType(), is("text/html; charset=UTF-8"));
+
+    }
+
+    @Test
+    public void testCustomUsingProperties() throws Exception {
+        EnvironmentTestUtils.addEnvironment(this.context,
+            "mixer2.order:0",
+            "mixer2.prefix:classpath:/m2mockup/custom-templates/",
+            "mixer2.suffix:.htm",
+            "mixer2.view-base-package:org.mixer2.spring.boot.app.view",
+            "mixer2.view-class-name-suffix:ScreenView",
+            "mixer2.content-type:text/html; charset=UTF-16",
+            "mixer2.doc-type:<!DOCTYPE html>");
+        this.context.register(AppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        assertThat(this.context.getBeanNamesForType(Mixer2Engine.class).length, is(1));
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        assertThat(viewResolver.getOrder(), is(0));
+
+        CustomScreenView view = (CustomScreenView) viewResolver.resolveViewName("custom", Locale.US);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        view.render(null, new MockHttpServletRequest(), response);
+        assertThat(response.getContentAsString(), is("<!DOCTYPE html>\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<body>custom default</body>\n</html>"));
+        assertThat(response.getContentType(), is("text/html; charset=UTF-16"));
+    }
+
+    @Test
+    public void testCustomCacheIsFalseUsingProperties() throws Exception {
+        EnvironmentTestUtils.addEnvironment(this.context,
+            "mixer2.cache:false",
+            "mixer2.cache-limit:4000",
+            "mixer2.cache-unresolved:false");
+        this.context.register(AppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        assertThat(this.context.getBeanNamesForType(Mixer2Engine.class).length, is(1));
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        assertThat(viewResolver.isCache(), is(false));
+        assertThat(viewResolver.getCacheLimit(), is(0));
+        assertThat(viewResolver.isCacheUnresolved(), is(true));
+
+    }
+
+    @Test
+    public void testCustomCacheParametersUsingProperties() throws Exception {
+        EnvironmentTestUtils.addEnvironment(this.context,
+            "mixer2.cache:true",
+            "mixer2.cache-limit:512",
+            "mixer2.cache-unresolved:false");
+        this.context.register(AppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        assertThat(this.context.getBeanNamesForType(Mixer2Engine.class).length, is(1));
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        assertThat(viewResolver.isCache(), is(true));
+        assertThat(viewResolver.getCacheLimit(), is(512));
+        assertThat(viewResolver.isCacheUnresolved(), is(false));
+    }
+
+    @Test
+    public void testNotFoundTemplateFileOnDefaultConfiguration() throws Exception {
+        this.context.register(AppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        View view = viewResolver.resolveViewName("foo", Locale.US);
+        assertThat(view, nullValue());
+    }
+
+    @Test
+    public void testNotFoundTemplateFileOnReturnNullIfTemplateFileNotFoundIsFalse() throws Exception {
+        EnvironmentTestUtils.addEnvironment(this.context,
+            "mixer2.return-null-if-template-file-not-found:false");
+        this.context.register(AppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        AbstractMixer2XhtmlView view = (AbstractMixer2XhtmlView) viewResolver.resolveViewName("foo", Locale.US);
+        assertThat(view.getUrl(), is("classpath:/m2mockup/templates/foo.html"));
+    }
+
+
+    @Test
+    public void testNotFoundViewClassOnDefaultConfiguration() throws Exception {
+        this.context.register(AppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        View view = viewResolver.resolveViewName("bar", Locale.US);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        view.render(null, new MockHttpServletRequest(), response);
+        assertThat(response.getContentAsString(), is("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\n<body>bar</body>\n</html>"));
+        assertThat(response.getContentType(), is("text/html; charset=UTF-8"));
+
+    }
+
+    @Test
+    public void testNotFoundViewClassOnRaiseErrorIfViewClassNotFoundIsTrue() throws Exception {
+        EnvironmentTestUtils.addEnvironment(this.context,
+            "mixer2.raise-error-if-view-class-not-found:true");
+        this.context.register(AppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        expectedException.expect(ClassNotFoundException.class);
+        expectedException.expectMessage(is("org.mixer2.spring.boot.web.view.BarView"));
+
+        Mixer2XhtmlViewResolver viewResolver = context.getBean(Mixer2XhtmlViewResolver.class);
+        viewResolver.resolveViewName("bar", Locale.US);
+
+    }
+
+
+    @Test
+    public void testFoundMultipleBasePackage() throws Exception {
+        EnvironmentTestUtils.addEnvironment(this.context,
+            "mixer2.raise-error-if-view-class-not-found:true");
+        this.context.register(AppConfig.class, SubPackageAppConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        expectedException.expect(ClassNotFoundException.class);
+        expectedException.expectMessage(is("BarView"));
+
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        viewResolver.resolveViewName("bar", Locale.US);
+
+    }
+
+    @Test
+    public void testCustomConfiguration() throws Mixer2JAXBException {
+        this.context.register(CustomConfig.class, Mixer2AutoConfiguration.class);
+        this.context.refresh();
+
+        Mixer2Engine engine = this.context.getBean(Mixer2Engine.class);
+        try {
+            engine.checkAndLoadHtmlTemplate("foo");
+        } catch (UnsupportedOperationException e) {
+            assertThat(e.getMessage(), is("error"));
+        }
+
+        Mixer2XhtmlViewResolver viewResolver = this.context.getBean(Mixer2XhtmlViewResolver.class);
+        assertThat(viewResolver.isCache(), is(false));
+
+    }
+
+    @SpringBootApplication
+    static class AppConfig {
+    }
+
+    static class CustomConfig {
+
+        @Bean
+        Mixer2Engine mixer2Engine() {
+            return new Mixer2Engine() {
+                @Override
+                public Html checkAndLoadHtmlTemplate(String str) throws Mixer2JAXBException {
+                    throw new UnsupportedOperationException("error");
+                }
+            };
+        }
+
+        @Bean
+        Mixer2XhtmlViewResolver mixer2XhtmlViewResolver() {
+            Mixer2XhtmlViewResolver viewResolver = new Mixer2XhtmlViewResolver();
+            viewResolver.setCache(false);
+            return viewResolver;
+        }
+
+    }
+
+}

--- a/src/test/java/org/mixer2/spring/boot/app/view/CustomScreenView.java
+++ b/src/test/java/org/mixer2/spring/boot/app/view/CustomScreenView.java
@@ -1,0 +1,15 @@
+package org.mixer2.spring.boot.app.view;
+
+import org.mixer2.jaxb.xhtml.Html;
+import org.mixer2.spring.webmvc.AbstractMixer2XhtmlView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+public class CustomScreenView extends AbstractMixer2XhtmlView {
+    @Override
+    protected Html renderHtml(Html html, Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        return html;
+    }
+}

--- a/src/test/java/org/mixer2/spring/boot/config/SubPackageAppConfig.java
+++ b/src/test/java/org/mixer2/spring/boot/config/SubPackageAppConfig.java
@@ -1,0 +1,7 @@
+package org.mixer2.spring.boot.config;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+@EnableAutoConfiguration
+public class SubPackageAppConfig {
+}

--- a/src/test/java/org/mixer2/spring/boot/web/view/DefaultView.java
+++ b/src/test/java/org/mixer2/spring/boot/web/view/DefaultView.java
@@ -1,0 +1,15 @@
+package org.mixer2.spring.boot.web.view;
+
+import org.mixer2.jaxb.xhtml.Html;
+import org.mixer2.spring.webmvc.AbstractMixer2XhtmlView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+public class DefaultView extends AbstractMixer2XhtmlView {
+    @Override
+    protected Html renderHtml(Html html, Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        return html;
+    }
+}

--- a/src/test/resources/m2mockup/custom-templates/custom.htm
+++ b/src/test/resources/m2mockup/custom-templates/custom.htm
@@ -1,0 +1,1 @@
+<html xmlns="http://www.w3.org/1999/xhtml"><body>custom default</body></html>

--- a/src/test/resources/m2mockup/templates/bar.html
+++ b/src/test/resources/m2mockup/templates/bar.html
@@ -1,0 +1,1 @@
+<html xmlns="http://www.w3.org/1999/xhtml"><body>bar</body></html>

--- a/src/test/resources/m2mockup/templates/default.html
+++ b/src/test/resources/m2mockup/templates/default.html
@@ -1,0 +1,1 @@
+<html xmlns="http://www.w3.org/1999/xhtml"><body>default</body></html>


### PR DESCRIPTION
I will suggest to add the auto configuration class for spring boot !

そして以降は、日本語で。

ども〜。久々にMixer 2にcontributeしてみよう。（JJUGのスライド見てふとw）
（２つBean定義すればよいだけなので、作る必要はない気はしたけど）Spring BootのAuto Configurationクラスつくってみました。 Mixer 2も推奨構成で作れば設定レスだよ〜的な。

デフォルト値はリファレンスの設定値を参考にしましたが、templateファイルを格納するパスどうしようかな〜と少し悩みました。Spring Boot的にはclasspath:/templates/だしな〜と。
あ〜あと、非Boot環境で誤作動しないかちょっと不安・・・。

ほんとは別プロジェクトの方がいいのかもしれないですが、いったん本家に混ぜ込んでPRしてみました。

ちなみに・・・Mixer 2って`ResourceUrlEncodingFilter`との連携（静的リソースへのURLとかにバージョンをつけられるやつ）ってサポートしてます？。もしサポートしてるなら、`ResourceUrlEncodingFilter`のBean定義も自動で定義してあげるとよさそう。

そのまま取り込んでもらうつもりでPRしてないんで、Auto Configurationサポートするなら参考にして頂ければ幸いです！！

ではでは。
